### PR TITLE
Fixed an error in parseSvg method.

### DIFF
--- a/app/widgets/com.capnajax.vectorimage/lib/svg.js
+++ b/app/widgets/com.capnajax.vectorimage/lib/svg.js
@@ -78,9 +78,9 @@ function SVGImage(svgString, options) {
 		_svgTag = svgString.substring(headerEndIdx, svgTagEnd);
 		_svgContent2 = svgString.substring(svgTagEnd, footerIndex);
 
-		var defsStartIdx = svgString.indexOf("<defs"),
+		var defsStartIdx = _svgContent2.indexOf("<defs"),
 			defsTagEnd = _svgContent2.indexOf(">", defsStartIdx) + 1,
-			defsEndIdx = svgString.indexOf("</defs>", defsStartIdx);
+			defsEndIdx = _svgContent2.indexOf("</defs>", defsStartIdx);
 
 		if(defsStartIdx !== -1 && defsEndIdx === -1) {
 


### PR DESCRIPTION
The lines 81 and 83 were wrong, as the generated idx are to be used with the _svgContent2 variable.
This error prevented some valid svg files to be parsed.
